### PR TITLE
Use atom-text-editor as the command scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # space-underscore package
 
-Inserts a underscore with shift+space. Particularly useful for
-Python programming, where identifiers_with_lots_of_underscores
+Inserts a underscore with <kbd>Shift+Space</kbd>. Particularly useful for
+Python or Ruby programming, where `identifiers_with_lots_of_underscores`
 are frequently typed.

--- a/keymaps/space-underscore.cson
+++ b/keymaps/space-underscore.cson
@@ -1,4 +1,4 @@
 # keymap
 
-'atom-workspace':
+'atom-text-editor':
   'shift-space': 'space-underscore:insert'

--- a/lib/space-underscore.coffee
+++ b/lib/space-underscore.coffee
@@ -15,4 +15,4 @@ module.exports = SpaceUnderscore =
 
   insert: ->
     editor = atom.workspace.getActiveTextEditor()
-    editor.insertText('_')
+    editor?.insertText('_')

--- a/lib/space-underscore.coffee
+++ b/lib/space-underscore.coffee
@@ -8,11 +8,11 @@ module.exports = SpaceUnderscore =
     @subscriptions = new CompositeDisposable
 
     # Register command that toggles this view
-    @subscriptions.add atom.commands.add 'atom-workspace', 'space-underscore:insert': => @insert()
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'space-underscore:insert': => @insert()
 
   deactivate: ->
     @subscriptions.dispose()
 
   insert: ->
-    editor = atom.workspace.activePaneItem
+    editor = atom.workspace.getActiveTextEditor()
     editor.insertText('_')


### PR DESCRIPTION
The key binding doesn't necessarily need to be available in every screen. This scopes the command just to text editors. I also changed to getting only the active text editor in the `insert()` method, in case the active pane item isn't a text editor ... where this command wouldn't make sense.
